### PR TITLE
Refactor app test to use mocked map

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,12 +4,21 @@ import { render } from '@testing-library/react';
 
 import App from './App';
 
+import {
+  setCenter,
+  setMap,
+} from './services/map';
+
+jest.mock('./services/map');
+
 describe('App', () => {
-  // TODO: 아래 kakao 객체를 한 번에 모킹하고 싶은데 어떻게 해야 하는지 모르겠다
-  global.kakao = jest.fn();
-  global.kakao.maps = jest.fn();
-  global.kakao.maps.LatLng = jest.fn();
-  global.kakao.maps.Map = jest.fn();
+  beforeEach(() => {
+    setCenter.mockClear();
+    setMap.mockClear();
+
+    setCenter.mockImplementation(() => null);
+    setMap.mockImplementation(() => null);
+  });
 
   it('renders title', () => {
     const { container } = render(<App />);
@@ -20,6 +29,7 @@ describe('App', () => {
   it('renders map', () => {
     render(<App />);
 
-    expect(global.kakao.maps.Map).toHaveBeenCalled();
+    expect(setCenter).toHaveBeenCalled();
+    expect(setMap).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# 관련 이슈

#1 

# 진행상황

* App 컴포넌트 테스트 코드에서 지도 Web API를 mocking 해서 사용한다.