### PR TITLE
Use absolute path in loading script

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,9 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 module.exports = {
   mode: 'development',
   entry: path.resolve(__dirname, 'src/index.jsx'),
+  output: {
+    publicPath: '/',
+  },
   plugins: [
     new webpack.DefinePlugin({
       'process.env.REST_API_KEY': JSON.stringify(process.env.REST_API_KEY),


### PR DESCRIPTION
Change webpack config to use absolute path when output file is loading script.

See also:
- https://webpack.js.org/configuration/output/#outputpublicpath