### PR TITLE
Add 404 error page to redirect nonexistent url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,9 @@ jobs:
     - name: Lint
       run: npm run lint
     - name: Build
-      run: npm run build
+      run: |
+        npm run build
+        cp dist/index.html dist/404.html
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
When Github Actions run, it automatically creates `404.html` to dist
folder.

`404.html` is created by copying `index.html`.

See also:
- https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site