### PR TITLE
Remove vertical scroll in chrome

### DIFF
--- a/assets/css/default.css
+++ b/assets/css/default.css
@@ -7,11 +7,17 @@
 }
 
 html {
+  width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 body {
   font-family: "Noto Sans KR", sans-serif;
   height: 100%;
   overflow: hidden;
+}
+
+#app {
+  height: 100%;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,7 +49,7 @@ export default function App() {
   }
 
   const Container = styled.div({
-    height: '100vh',
+    height: '100%',
     display: 'flex',
     flexDirection: 'column',
 


### PR DESCRIPTION
Remove vertical scroll in mobile chrome caused by URL address bar.

Replace `height: 100vh` with `height: 100%` in App component because viewport height unit is dependent on when URL bar is shown or hidden in mobile chrome.

See also:
- https://developers.google.com/web/updates/2016/12/url-bar-resizing